### PR TITLE
Perform gc

### DIFF
--- a/amazonka-s3-streaming.cabal
+++ b/amazonka-s3-streaming.cabal
@@ -31,6 +31,7 @@ library
                        , dlist
                        , lifted-async
                        , mmap
+                       , deepseq
 
   if impl(ghc < 7.11)
     build-depends:
@@ -48,7 +49,7 @@ source-repository head
 
 executable s3upload
   main-is: Main.hs
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N -O2
   default-language: Haskell2010
   build-depends: base >= 4.7 && < 5
                  , amazonka

--- a/amazonka-s3-streaming.cabal
+++ b/amazonka-s3-streaming.cabal
@@ -31,7 +31,7 @@ library
                        , dlist
                        , lifted-async
                        , mmap
-                       , deepseq
+                       , deepseq          >= 1.4
 
   if impl(ghc < 7.11)
     build-depends:

--- a/src/Network/AWS/S3/StreamingUpload.hs
+++ b/src/Network/AWS/S3/StreamingUpload.hs
@@ -131,7 +131,7 @@ streamUpload cmu = do
                     go empty 0 hashInit (partnum+1) . D.snoc completed $! part
 
         Nothing -> lift $ do
-            parts <- if bufsize > 0
+            prts <- if bufsize > 0
                 then do
                     rs <- partUploader partnum bufsize (hashFinalize ctx) bss
 
@@ -144,7 +144,7 @@ streamUpload cmu = do
                     pure $ nonEmpty =<< sequence (D.toList completed)
 
             send $ completeMultipartUpload bucket key upId
-                    & cMultipartUpload ?~ set cmuParts parts completedMultipartUpload
+                    & cMultipartUpload ?~ set cmuParts prts completedMultipartUpload
 
 
       partUploader :: MonadAWS m => Int -> Int -> Digest SHA256 -> D.DList ByteString -> m UploadPartResponse

--- a/src/Network/AWS/S3/StreamingUpload.hs
+++ b/src/Network/AWS/S3/StreamingUpload.hs
@@ -140,8 +140,8 @@ streamUpload cmu = do
                     let allParts = D.toList $ D.snoc completed $ completedPart partnum <$> (rs ^. uprsETag)
                     pure $ nonEmpty =<< sequence allParts
                 else do
-                  logStr $ printf "\n**** No final data to upload\n" partnum bufsize
-                  pure $ nonEmpty =<< sequence (D.toList completed)
+                    logStr $ printf "\n**** No final data to upload\n"
+                    pure $ nonEmpty =<< sequence (D.toList completed)
 
             send $ completeMultipartUpload bucket key upId
                     & cMultipartUpload ?~ set cmuParts parts completedMultipartUpload


### PR DESCRIPTION
A few improvements to help with performance, perform a GC once we've send a part in the streaming interface, deepseq the CompletedPart data so we're not holding references to the part upload results.