### PR TITLE
 Address `http-client-0.5.8` removal of `mMaxConns`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 Provides a conduit based streaming interface and a concurrent interface to uploading data to S3 using the Multipart API. Also provides method to upload files or bytestrings of known size in parallel.
 
 The documentation can be found on [Hackage](https://hackage.haskell.org/package/amazonka-s3-streaming).
+

--- a/src/Network/AWS/S3/StreamingUpload.hs
+++ b/src/Network/AWS/S3/StreamingUpload.hs
@@ -75,7 +75,6 @@ import           System.Mem                             (performGC)
 import           Network.HTTP.Client                    (defaultManagerSettings,
                                                          managerConnCount,
                                                          newManager)
-import           Network.HTTP.Client.Internal           (mMaxConns)
 
 type ChunkSize = Int
 type NumThreads = Int
@@ -219,8 +218,7 @@ concurrentUpload mcs mnt ud cmu = do
             let chunkSize' = maybe minimumChunkSize (max minimumChunkSize) mcs
             in if len `div` chunkSize' >= 10000 then len `div` 9999 else chunkSize'
 
-    mgr <- view envManager
-    let mConnCount = mMaxConns mgr
+    let mConnCount = managerConnCount defaultManagerSettings
         nThreads = maybe mConnCount (max 1) mnt
         exec run = if maybe False (> mConnCount) mnt
                 then do


### PR DESCRIPTION
Default to the static default-setting conn-count, since we can no longer find the manager's max conn-count or the settings its running with.