### PR TITLE
Support conduit-1.3

### DIFF
--- a/amazonka-s3-streaming.cabal
+++ b/amazonka-s3-streaming.cabal
@@ -30,9 +30,9 @@ library
                        , mmorph           >= 1.0.6      && < 1.2
                        , lens             >= 4.13       && < 5.0
                        , mtl              >= 2.2.1      && < 2.3
-                       , exceptions       >= 0.8.2.1    && < 0.9
+                       , exceptions       >= 0.8.2.1    && < 0.11
                        , dlist            >= 0.8        && < 0.9
-                       , lifted-async     >= 0.9        && < 0.10
+                       , lifted-async     >= 0.9        && < 0.10.1
                        , mmap             >= 0.5        && < 0.6
                        , deepseq          >= 1.2        && < 1.5
                        , http-client      >= 0.4        && < 0.6

--- a/amazonka-s3-streaming.cabal
+++ b/amazonka-s3-streaming.cabal
@@ -25,9 +25,9 @@ library
                        , amazonka-core    >= 1.3        && < 1.7
                        , amazonka-s3      >= 1.3        && < 1.7
                        , resourcet        >= 1.1.7.4    && < 1.4
-                       , conduit          >= 1.2.6.6    && < 1.4
                        , bytestring       >= 0.10.8.0   && < 0.11
                        , mmorph           >= 1.0.6      && < 1.2
+                       , monad-control    >= 1.0        && < 1.1
                        , lens             >= 4.13       && < 5.0
                        , mtl              >= 2.2.1      && < 2.3
                        , exceptions       >= 0.8.2.1    && < 0.11
@@ -36,7 +36,13 @@ library
                        , mmap             >= 0.5        && < 0.6
                        , deepseq          >= 1.2        && < 1.5
                        , http-client      >= 0.4        && < 0.6
-                       , unliftio         >= 0.2        && < 0.3
+  if flag(conduit_1_3)
+    build-depends:
+      conduit          >= 1.3    && < 1.4
+      , unliftio       >= 0.2    && < 0.3
+  else
+    build-depends:
+      conduit          >= 1.2.6.6 && < 1.3
 
   if impl(ghc < 7.11)
     build-depends:
@@ -53,6 +59,10 @@ library
 
 Flag s3upload-exe
   Description: Whether to build the s3upload executable for uploading files using this library.
+  Default: False
+
+Flag conduit_1_3
+  Description: Whether to use conduit >= 1.3
   Default: False
 
 source-repository head

--- a/amazonka-s3-streaming.cabal
+++ b/amazonka-s3-streaming.cabal
@@ -21,11 +21,11 @@ library
   exposed-modules:     Network.AWS.S3.StreamingUpload
   default-language:    Haskell2010
   build-depends:       base >= 4.6 && < 5
-                       , amazonka         >= 1.3        && < 1.6
-                       , amazonka-core    >= 1.3        && < 1.6
-                       , amazonka-s3      >= 1.3        && < 1.6
-                       , resourcet        >= 1.1.7.4    && < 1.2
-                       , conduit          >= 1.2.6.6    && < 1.3
+                       , amazonka         >= 1.3        && < 1.7
+                       , amazonka-core    >= 1.3        && < 1.7
+                       , amazonka-s3      >= 1.3        && < 1.7
+                       , resourcet        >= 1.1.7.4    && < 1.4
+                       , conduit          >= 1.2.6.6    && < 1.4
                        , bytestring       >= 0.10.8.0   && < 0.11
                        , mmorph           >= 1.0.6      && < 1.2
                        , lens             >= 4.13       && < 5.0
@@ -36,6 +36,7 @@ library
                        , mmap             >= 0.5        && < 0.6
                        , deepseq          >= 1.2        && < 1.5
                        , http-client      >= 0.4        && < 0.6
+                       , unliftio         >= 0.2        && < 0.3
 
   if impl(ghc < 7.11)
     build-depends:
@@ -44,12 +45,12 @@ library
   if impl(ghc == 7.8.*)
     build-depends:
       foundation == 0.0.15
-  
+
   -- -- ini 0.3.4 fails to build because it doesn't have <*
   -- if impl(ghc < 7.9)
   --   build-depends:
   --     ini >= 0.3.5
-  
+
 Flag s3upload-exe
   Description: Whether to build the s3upload executable for uploading files using this library.
   Default: False

--- a/src/Network/AWS/S3/StreamingUpload.hs
+++ b/src/Network/AWS/S3/StreamingUpload.hs
@@ -48,6 +48,9 @@ import           Control.Monad.Reader.Class             (local)
 
 #if MIN_VERSION_resourcet(1,2,1)
 import           Control.Monad.Trans.Resource           (MonadResource, MonadUnliftIO)
+#if !MIN_VERSION_amazonka(1,6,1)
+import           Control.Monad.Trans.Control            (MonadBaseControl)
+#endif
 #else
 import           Control.Monad.Trans.Resource           (MonadResource, MonadBaseControl)
 #endif
@@ -106,7 +109,7 @@ See the AWS documentation for more details.
 
 May throw 'Network.AWS.Error'
 -}
-#if MIN_VERSION_resourcet(1,2,1)
+#if MIN_VERSION_conduit(1,3,0)
 streamUpload :: (MonadResource m, MonadAWS m, MonadUnliftIO m)
 #else
 streamUpload :: (MonadResource m, MonadAWS m, MonadBaseControl IO m)

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: nightly-2018-05-30
+resolver: lts-7.14
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -40,14 +40,7 @@ packages:
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps:
-- unliftio-0.2.7.0
-- unliftio-core-0.1.1.0
-- git: git@github.com:brendanhay/amazonka.git
-  commit: 248f7b2a7248222cc21cef6194cd1872ba99ac5d
-  subdirs:
-  - amazonka
-
+extra-deps: []
 # Override default flag values for local packages and extra-deps
 flags: {}
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,7 +39,10 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- unliftio-0.2.7.0
+- async-2.1.1.1
+- unliftio-core-0.1.1.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-7.14
+resolver: nightly-2018-05-30
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -37,12 +37,16 @@ resolver: lts-7.14
 # will not be run. This is useful for tweaking upstream packages.
 packages:
 - '.'
+
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:
 - unliftio-0.2.7.0
-- async-2.1.1.1
 - unliftio-core-0.1.1.0
+- git: git@github.com:brendanhay/amazonka.git
+  commit: 248f7b2a7248222cc21cef6194cd1872ba99ac5d
+  subdirs:
+  - amazonka
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
They changed the API to use `MonadUnliftIO` rather than `MonadBaseControl IO`.