### PR TITLE
Use MonadFail constraint

### DIFF
--- a/amazonka-s3-streaming.cabal
+++ b/amazonka-s3-streaming.cabal
@@ -14,13 +14,13 @@ category:            Network, AWS, Cloud, Distributed Computing
 build-type:          Simple
 extra-source-files:  README.md, Changelog.md
 cabal-version:       >=1.10
-tested-with:         GHC == 8.0.* || == 8.2.2 || == 8.4.* || == 8.6.*
+tested-with:         GHC == 8.0.* || == 8.2.2 || == 8.4.* || == 8.6.* || == 8.8.*
 
 library
   hs-source-dirs:      src
   exposed-modules:     Network.AWS.S3.StreamingUpload
   default-language:    Haskell2010
-  build-depends:       base >= 4.6 && < 5
+  build-depends:       base >= 4.9 && < 5
                        , amazonka         >= 1.6        && < 1.7
                        , amazonka-core    >= 1.6        && < 1.7
                        , amazonka-s3      >= 1.6        && < 1.7


### PR DESCRIPTION
As per [MonadFailProposal][]'s last step, `fail` is removed from `Monad` and instead provided by `MonadFail` starting from `base-4.13`.

`MonadFail` typeclass was introduced on `base-4.9` coming with `GHC 8.x`; so this PR bumps the lower bound of `base` to reflect that. This makes the library explicitly drop support for GHC 7.x; let me know if this is important for you, we might need to add some CPP in that case.

This PR adds `MonadFail` constraints to functions using `fail`. This is technically a backwards-incompatible change since there's an additional constraint on the public API, but practically it is not a big issue since monads with `MonadIO` instances usually comes with `MonadFail` too.

[MonadFailProposal]: https://wiki.haskell.org/MonadFail_Proposal