### PR TITLE
Rewrite streamUpload

### DIFF
--- a/amazonka-s3-streaming.cabal
+++ b/amazonka-s3-streaming.cabal
@@ -49,7 +49,7 @@ source-repository head
 
 executable s3upload
   main-is: Main.hs
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -threaded -rtsopts "-with-rtsopts=-N -qg"
   default-language: Haskell2010
   if flag(s3upload-exe)
      buildable: True

--- a/amazonka-s3-streaming.cabal
+++ b/amazonka-s3-streaming.cabal
@@ -27,7 +27,6 @@ library
                        , conduit          >= 1.3        && < 1.4
                        , conduit-concurrent-map
                        , bytestring       >= 0.10.8.0   && < 0.11
-                       , bytestring-to-vector
                        , mmorph           >= 1.0.6      && < 1.2
                        , lens             >= 4.13       && < 5.0
                        , mtl              >= 2.2.1      && < 2.3

--- a/amazonka-s3-streaming.cabal
+++ b/amazonka-s3-streaming.cabal
@@ -62,5 +62,6 @@ executable s3upload
                  , amazonka-s3-streaming
                  , conduit-extra
                  , conduit
+                 , lens
                  , text
 

--- a/amazonka-s3-streaming.cabal
+++ b/amazonka-s3-streaming.cabal
@@ -25,14 +25,18 @@ library
                        , amazonka-core    >= 1.6        && < 1.7
                        , amazonka-s3      >= 1.6        && < 1.7
                        , conduit          >= 1.3        && < 1.4
+                       , conduit-concurrent-map
                        , bytestring       >= 0.10.8.0   && < 0.11
+                       , bytestring-to-vector
                        , mmorph           >= 1.0.6      && < 1.2
                        , lens             >= 4.13       && < 5.0
                        , mtl              >= 2.2.1      && < 2.3
                        , exceptions       >= 0.8.2.1    && < 0.11
-                       , dlist            >= 0.8        && < 0.9
+                       , resourcet
                        , async            >= 2          && < 2.3
                        , http-client      >= 0.4        && < 0.7
+                       , vector
+                       , text
 
 flag s3upload-exe
   Description: Whether to build the s3upload executable for uploading files using this library.

--- a/src/Network/AWS/S3/StreamingUpload.hs
+++ b/src/Network/AWS/S3/StreamingUpload.hs
@@ -51,8 +51,6 @@ import           Data.ByteString                 ( ByteString )
 import qualified Data.ByteString                as BS
 import           Data.ByteString.Builder         ( stringUtf8 )
 import           Data.ByteString.Unsafe          (unsafeIndex)
-import qualified Data.Vector.Storable as VS
-import           Data.Vector.Storable.ByteString (vectorToByteString)
 import           Data.List                       ( unfoldr )
 import           Data.List.NonEmpty              ( nonEmpty, fromList )
 import Data.Text (Text)

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,12 +40,16 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps: 
-- amazonka-1.6.1@sha256:f58b63e83876f93aa03c54e54b3eb8ba9358af93819d41f4a5a8f8b7d8b8399c,3544
-- amazonka-core-1.6.1@sha256:9bc59ce403c6eeba3b3eaf3f10e5f0b6a33b6edbbf8f6de0dd6f4c67b86fa698,5135
-- amazonka-s3-1.6.1@sha256:9d07240fca59ad5197fb614ce3051e701e4951e6d4625a2dab4a9c17a1900194,6317
-
+- git: https://github.com/brendanhay/amazonka
+  commit: ed7630edacc09e627ed0ee59126f4cdca0d73a0c
+  subdirs:
+    - amazonka
+    - amazonka-s3
+    - core
 # Override default flag values for local packages and extra-deps
-flags: {}
+flags:
+  amazonka-s3-streaming:
+    s3upload-exe: true
 
 # Extra package databases containing global packages
 extra-package-dbs: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-13.18
+resolver: lts-15.11
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -39,7 +39,10 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps: 
+- amazonka-1.6.1@sha256:f58b63e83876f93aa03c54e54b3eb8ba9358af93819d41f4a5a8f8b7d8b8399c,3544
+- amazonka-core-1.6.1@sha256:9bc59ce403c6eeba3b3eaf3f10e5f0b6a33b6edbbf8f6de0dd6f4c67b86fa698,5135
+- amazonka-s3-1.6.1@sha256:9d07240fca59ad5197fb614ce3051e701e4951e6d4625a2dab4a9c17a1900194,6317
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
I wanted to rewrite streaming to improve performance of chunking. `DList` is quite inefficient compared to vectorBuilder. See https://www.fpcomplete.com/blog/2014/07/vectorbuilder-packed-conduit-yielding

A few improvements along the way:

- control flow is still a mess, bit I think a bit better now
- concurrent uploads during streaming

Need testing.

Out of scope: rewriting `concurrentUpload` in terms of `streamUpload`
